### PR TITLE
One_jump_limit-Band-aid

### DIFF
--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -1408,7 +1408,7 @@ public Action Event_PlayerJump(Handle event, char[] name, bool dontBroadcast)
 						g_bJumpedInZone[client] = true;
 						g_bResetOneJump[client] = true;
 						g_fJumpedInZoneTime[client] = GetGameTime();
-						CreateTimer(1.0, ResetOneJump, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
+						CreateTimer(1.5, ResetOneJump, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 					}
 					else
 					{


### PR DESCRIPTION
This is more of a band-aid than anything else.

This does allow you to get more than 1 jump in whilst not moving or moving at a very low speed <100u/s however when moving at speed that actually matters then it seems to work as it should. 

I spent 10+ mins jumping in a zone and i could not break it. I also was not in any way able to use this to my advantage.