### PR TITLE
Add LG/SM cTime thresholds for prehop prevention

### DIFF
--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -1374,7 +1374,10 @@ public Action Event_PlayerJump(Handle event, char[] name, bool dontBroadcast)
 						g_bJumpedInZone[client] = true;
 						g_bResetOneJump[client] = true;
 						g_fJumpedInZoneTime[client] = GetGameTime();
-						CreateTimer(1.0, ResetOneJump, client, TIMER_FLAG_NO_MAPCHANGE);
+						if (g_iCurrentStyle[client] == 5 || g_iCurrentStyle[client] == 4)
+							CreateTimer(1.7, ResetOneJump, client, TIMER_FLAG_NO_MAPCHANGE);
+						else
+							CreateTimer(1.0, ResetOneJump, client, TIMER_FLAG_NO_MAPCHANGE);
 					}
 					else
 					{
@@ -1382,7 +1385,7 @@ public Action Event_PlayerJump(Handle event, char[] name, bool dontBroadcast)
 						float time = GetGameTime();
 						float time2 = time - g_fJumpedInZoneTime[client];
 						g_bJumpedInZone[client] = false;
-						if (time2 <= 0.9)
+						if ((time2 <= 0.9 && g_iCurrentStyle[client] != 4 && g_iCurrentStyle[client] != 5) || (time2 <= 1.6 && (g_iCurrentStyle[client] == 4 || g_iCurrentStyle[client] == 5)))
 						{
 							CPrintToChat(client, "%t", "Hooks15", g_szChatPrefix);
 							Handle pack;

--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -1317,11 +1317,18 @@ public Action Event_PlayerJump(Handle event, char[] name, bool dontBroadcast)
 			{
 				if (g_bFirstJump[client])
 				{
-					if (cTime > 0.8)
+					if (cTime > 0.8 && g_iCurrentStyle[client] != 4 && g_iCurrentStyle[client] != 5) // cTime Normal Threshold + Exclude LG/SM
 					{
 						g_bFirstJump[client] = true;
 						g_iLastJump[client] = GetGameTime();
 					}
+
+					else if (cTime > 1.6 && (g_iCurrentStyle[client] == 4 || g_iCurrentStyle[client] == 5)) // LG/SM jump time threshold
+					{
+						g_bFirstJump[client] = true;
+						g_iLastJump[client] = GetGameTime();
+					}
+					
 					else
 					{
 						g_iLastJump[client] = GetGameTime();
@@ -1336,11 +1343,19 @@ public Action Event_PlayerJump(Handle event, char[] name, bool dontBroadcast)
 			}
 			else
 			{
-				if (cTime > 1)
+				// 0.2s no-jump buffer (cTime + 0.2) to register as no longer in bhop.
+				if (cTime > 1 && g_iCurrentStyle[client] != 4 && g_iCurrentStyle[client] != 5) // Not LG/SM
 				{
 					g_bInBhop[client] = false;
 					g_iLastJump[client] = GetGameTime();
 				}
+
+				else if (cTime > 1.8 && (g_iCurrentStyle[client] == 4 || g_iCurrentStyle[client] == 5)) // LG/SM
+				{
+					g_bInBhop[client] = false;
+					g_iLastJump[client] = GetGameTime();
+				}
+
 				else
 				{
 					g_iLastJump[client] = GetGameTime();


### PR DESCRIPTION
I figured out a way to extend the existing pre-hop prevention to accommodate the slower styles (Low-Gravity and Slow-Motion) by adding cTime thresholds that meet the style's requirements when checking for whether a player is currently in a bhop.

I initially tried re-working the system in agreement with sneaK's comment that the current system is pretty bad, but I ended up just giving up and trying to extend the current system. Until we get a full re-work, this should prevent pre-hopping in both Low-Gravity and Slow-Motion.

cTime Measurements: 
![image](https://user-images.githubusercontent.com/39123848/129898164-c0fc5327-fd01-4291-97d9-65985f463b42.png)
