### PR TITLE
Replace SQL_GetRowCount with SQL_FetchInt in SQL_ViewAllRecordsCallback2

### DIFF
--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -2647,7 +2647,7 @@ public void SQL_ViewAllRecordsCallback2(Handle owner, Handle hndl, const char[] 
 		char szSteamId[32];
 		char szMapName[128];
 
-		int rank = SQL_GetRowCount(hndl);
+		int rank = SQL_FetchInt(hndl, 0);
 		WritePackCell(data, rank);
 		ResetPack(data);
 		ReadPackString(data, szName, MAX_NAME_LENGTH);


### PR DESCRIPTION
This is a super quick fix for the completed maps list in profiles always displaying Rank 1 instead of the correct rank.

![Old](https://i.rebooti.ng/f/dpxbg.png)

After replacing SQL_GetRowCount:
![New](https://i.rebooti.ng/f/5wt5v.png)