### PR TITLE
Specify style = 0 when running db_selectPlayerRank

### DIFF
--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -7789,12 +7789,12 @@ public void db_selectPlayerRank(int client, int rank, char szSteamId[32])
 	{
 		g_rankArg[client] = rank;
 		rank -= 1;
-		Format(szQuery, 1024, "SELECT `name`, `points` FROM `ck_playerrank` ORDER BY `points` DESC LIMIT %i, 1;", rank);
+		Format(szQuery, 1024, "SELECT `name`, `points` FROM `ck_playerrank` WHERE `style` = 0 ORDER BY `points` DESC LIMIT %i, 1;", rank);
 	}
 	else if (rank == 0) // Self Rank Cmd
 	{
 		g_rankArg[client] = -1;
-		Format(szQuery, 1024, "SELECT `name`, `points` FROM `ck_playerrank` WHERE `steamid` = '%s';", szSteamId);
+		Format(szQuery, 1024, "SELECT `name`, `points` FROM `ck_playerrank` WHERE `steamid` = '%s' AND `style` = 0;", szSteamId);
 	}
 
 	SQL_TQuery(g_hDb, db_selectPlayerRankCallback, szQuery, client, DBPrio_Low);


### PR DESCRIPTION
This is a tiny modification to the queries used in the `db_selectPlayerRank` function. When players use the `/rank @#` command to check someone's rank and points in the chat, the `db_selectPlayerRank` can display style ranks and points, often leading to confusion.

A good example of this can be seen in the screenshots below. The first screenshot showcases the `/rank @1` command before this fix - the expected result should be "w", but we instead see Dini's slow motion top rank and score.
![image](https://user-images.githubusercontent.com/39123848/132128564-88207601-64c8-4673-963e-baded3c38aa8.png)


With this fix, issuing the same command gives us the expected results:
![image](https://user-images.githubusercontent.com/39123848/132128546-abd8afc9-4d6f-4b26-a5db-caaca4d687fa.png)

