### PR TITLE
Update and fix replay

### DIFF
--- a/addons/sourcemod/scripting/surftimer/buttonpress.sp
+++ b/addons/sourcemod/scripting/surftimer/buttonpress.sp
@@ -128,18 +128,13 @@ public void CL_OnStartTimerPress(int client)
 	// Start recording for record bot
 	if ((!IsFakeClient(client) && GetConVarBool(g_hReplayBot)) || (!IsFakeClient(client) && GetConVarBool(g_hBonusBot)))
 	{
-		if (!IsPlayerAlive(client) || GetClientTeam(client) == 1)
+		if (IsPlayerAlive(client))
 		{
-			if (g_hRecording[client] != null)
-				StopRecording(client);
-		}
-		else
-		{
-			if (g_hRecording[client] != null)
-				StopRecording(client);
 			StartRecording(client);
 			if (g_bhasStages)
+			{
 				Stage_StartRecording(client);
+			}
 		}
 	}
 }

--- a/addons/sourcemod/scripting/surftimer/convars.sp
+++ b/addons/sourcemod/scripting/surftimer/convars.sp
@@ -441,7 +441,8 @@ void CreateConVars()
 	g_Offset_m_fEffects = FindSendPropInfo("CBaseEntity", "m_fEffects");
 
 	// Server Tickate
-	g_Server_Tickrate = RoundFloat(1 / GetTickInterval());
+	g_iTickrate = RoundFloat(1 / GetTickInterval());
+	g_fTickrate = (1 / GetTickInterval());
 
 	// Footsteps
 	g_hFootsteps = FindConVar("sv_footsteps");

--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -126,10 +126,10 @@ public Action Event_OnPlayerSpawn(Handle event, const char[] name, bool dontBroa
 		else
 			SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 5, 4, true);
 
-		// Botmimic3
-		if (g_hBotMimicsRecord[client] != null && IsFakeClient(client))
+		// Replay bot frame init
+		if (g_aReplayFrame[client] != null && IsFakeClient(client))
 		{
-			g_BotMimicTick[client] = 0;
+			g_iReplayTick[client] = 0;
 			g_CurrentAdditionalTeleportIndex[client] = 0;
 		}
 
@@ -609,22 +609,40 @@ public Action Event_OnPlayerDeath(Handle event, const char[] name, bool dontBroa
 	int client = GetEventInt(event, "userid");
 	if (IsValidClient(client))
 	{
+		RemoveRagdoll(client);
+
 		if (!IsFakeClient(client))
 		{
-			if (g_hRecording[client] != null)
+			if (g_aRecording[client] != null)// should detect player if is onTimer
+			{
 				StopRecording(client);
-			CreateTimer(2.0, RemoveRagdoll, client);
+			}
 		}
 		else
-			if (g_hBotMimicsRecord[client] != null)
+		{
+			if (g_aReplayFrame[client] != null)
 			{
-				g_BotMimicTick[client] = 0;
+				g_iReplayTick[client] = 0;
 				g_CurrentAdditionalTeleportIndex[client] = 0;
 				if (GetClientTeam(client) >= CS_TEAM_T)
+				{
 					CreateTimer(1.0, RespawnBot, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
+				}
 			}
+		}
 	}
+
 	return Plugin_Continue;
+}
+
+static void RemoveRagdoll(int client)
+{
+	int iEntity = GetEntPropEnt(client, Prop_Send, "m_hRagdoll");
+
+	if(iEntity != INVALID_ENT_REFERENCE)
+	{
+		AcceptEntityInput(iEntity, "Kill");
+	}
 }
 
 public Action CS_OnTerminateRound(float &delay, CSRoundEndReason &reason)
@@ -771,12 +789,6 @@ public Action OnTouchPushTrigger(int entity, int other)
 	{
 		if (IsFakeClient(other))
 			return Plugin_Handled;
-
-		// Takes a new additional teleport to increase acuraccy for bot recordings.
-		if (g_hRecording[other] != null && !IsFakeClient(other))
-		{
-			g_createAdditionalTeleport[other] = true;
-		}
 
 		// fluffys
 		g_bInPushTrigger[other] = true;
@@ -1028,7 +1040,9 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	// Backwards
 
 	if (g_bRoundEnd || !IsValidClient(client))
+	{
 		return Plugin_Continue;
+	}
 
 	if (IsPlayerAlive(client))
 	{
@@ -1132,15 +1146,25 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 
 		if (newVelocity[0] == 0.0 && newVelocity[1] == 0.0 && newVelocity[2] == 0.0)
 		{
-			RecordReplay(client, buttons, subtype, seed, impulse, weapon, angles, vel);
 			if (IsFakeClient(client))
+			{
 				PlayReplay(client, buttons, subtype, seed, impulse, weapon, angles, vel);
+			}
+			else
+			{
+				RecordReplay(client, buttons, subtype, seed, impulse, weapon, angles, vel);
+			}
 		}
 		else
 		{
-			RecordReplay(client, buttons, subtype, seed, impulse, weapon, angles, newVelocity);
 			if (IsFakeClient(client))
+			{
 				PlayReplay(client, buttons, subtype, seed, impulse, weapon, angles, newVelocity);
+			}
+			else
+			{
+				RecordReplay(client, buttons, subtype, seed, impulse, weapon, angles, vel);
+			}
 		}
 
 		// Strafe Sync taken from shavit's bhoptimer
@@ -1272,7 +1296,7 @@ public MRESReturn DHooks_OnTeleport(int client, Handle hParams)
 	}
 
 	// This one is currently mimicing something.
-	if (g_hBotMimicsRecord[client] != null)
+	if (g_aReplayFrame[client] != null)
 	{
 		// We didn't allow that teleporting. STOP THAT.
 		if (!g_bValidTeleportCall[client])
@@ -1282,7 +1306,7 @@ public MRESReturn DHooks_OnTeleport(int client, Handle hParams)
 	}
 
 	// Don't care if he's not recording.
-	if (g_hRecording[client] == null)
+	if (g_aRecording[client] == null)
 		return MRES_Ignored;
 
 	bool bOriginNull = DHookIsNullParam(hParams, 1);
@@ -1305,22 +1329,6 @@ public MRESReturn DHooks_OnTeleport(int client, Handle hParams)
 
 	if (bOriginNull && bAnglesNull && bVelocityNull)
 		return MRES_Ignored;
-
-	AdditionalTeleport iAT;
-	Array_Copy(origin, iAT.AtOrigin, 3);
-	Array_Copy(angles, iAT.AtAngles, 3);
-	Array_Copy(velocity, iAT.AtVelocity, 3);
-
-	// Remember,
-	if (!bOriginNull)
-		iAT.AtFlags |= ADDITIONAL_FIELD_TELEPORTED_ORIGIN;
-	if (!bAnglesNull)
-		iAT.AtFlags |= ADDITIONAL_FIELD_TELEPORTED_ANGLES;
-	if (!bVelocityNull)
-		iAT.AtFlags |= ADDITIONAL_FIELD_TELEPORTED_VELOCITY;
-
-	if (g_hRecordingAdditionalTeleport[client] != null)
-		PushArrayArray(g_hRecordingAdditionalTeleport[client], iAT, sizeof(AdditionalTeleport));
 
 	return MRES_Ignored;
 }

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -2912,7 +2912,7 @@ public void AutoBhopFunction(int client, int &buttons)
 public void SpecListMenuDead(int client) // What Spectators see
 {
 	char szTick[32];
-	Format(szTick, 32, "%i", g_Server_Tickrate);
+	Format(szTick, 32, "%i", g_iTickrate);
 	int ObservedUser;
 	ObservedUser = -1;
 	char sSpecs[512];
@@ -3226,7 +3226,7 @@ public void CenterHudDead(int client)
 	char szTick[32];
 	char obsAika[128];
 	float obsTimer;
-	Format(szTick, 32, "%i", g_Server_Tickrate);
+	Format(szTick, 32, "%i", g_iTickrate);
 	int ObservedUser;
 	ObservedUser = -1;
 	int SpecMode;

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -1,4 +1,4 @@
-void setBotQuota()
+public void SetBotQuota()
 {
 	// Get bot_quota value
 	ConVar hBotQuota = FindConVar("bot_quota");
@@ -3156,7 +3156,7 @@ public void LoadInfoBot()
 	}
 	else
 	{
-		setBotQuota();
+		SetBotQuota();
 		CreateTimer(0.5, RefreshInfoBot, TIMER_FLAG_NO_MAPCHANGE);
 	}
 }

--- a/addons/sourcemod/scripting/surftimer/replay.sp
+++ b/addons/sourcemod/scripting/surftimer/replay.sp
@@ -1035,8 +1035,6 @@ public void PlayReplay(int client, int &buttons, int &subtype, int &seed, int &i
 		// We're supposed to teleport stuff?
 		if (iFrame.AdditionalFields & (ADDITIONAL_FIELD_TELEPORTED_ORIGIN | ADDITIONAL_FIELD_TELEPORTED_ANGLES | ADDITIONAL_FIELD_TELEPORTED_VELOCITY))
 		{
-			AdditionalTeleport iAT;
-			ArrayList hAdditionalTeleport;
 			char sPath[PLATFORM_MAX_PATH];
 			if (client == g_RecordBot)
 			{
@@ -1072,10 +1070,13 @@ public void PlayReplay(int client, int &buttons, int &subtype, int &seed, int &i
 			BuildPath(Path_SM, sPath, sizeof(sPath), "%s", sPath);
 			if (g_smLoadedRecordsAdditionalTeleport != null)
 			{
+				AdditionalTeleport iAT;
+				ArrayList hAdditionalTeleport = null;
 				g_smLoadedRecordsAdditionalTeleport.GetValue(sPath, hAdditionalTeleport);
 				if (hAdditionalTeleport != null)
 				{
 					hAdditionalTeleport.GetArray(g_CurrentAdditionalTeleportIndex[client], iAT, 10);
+					delete hAdditionalTeleport;
 				}
 
 				float fOrigin[3], fAngles[3], fVelocity[3];

--- a/addons/sourcemod/scripting/surftimer/replay.sp
+++ b/addons/sourcemod/scripting/surftimer/replay.sp
@@ -718,7 +718,7 @@ public bool LoadRecordFromFile(const char[] path, FileHeader header, bool header
 
 public Action RefreshBot(Handle timer)
 {
-	setBotQuota();
+	SetBotQuota();
 	LoadRecordReplay();
 	return Plugin_Handled;
 }
@@ -781,7 +781,7 @@ public void LoadRecordReplay()
 
 public Action RefreshBonusBot(Handle timer)
 {
-	setBotQuota();
+	SetBotQuota();
 	LoadBonusReplay();
 	return Plugin_Handled;
 }
@@ -845,7 +845,7 @@ public void LoadBonusReplay()
 
 public Action RefreshWrcpBot(Handle timer)
 {
-	setBotQuota();
+	SetBotQuota();
 	LoadWrcpReplay();
 	return Plugin_Handled;
 }
@@ -1373,7 +1373,7 @@ public void Stage_SaveRecording(int client, int stage, char[] time)
 	strcopy(header.Playername, sizeof(FileHeader::Playername), szName);
 	header.Checkpoints = 0;
 
-	ArrayList frames = new ArrayList(sizeof(FrameInfo));
+	ArrayList frames = new ArrayList(sizeof(frame_t));
 	any aFrameData[sizeof(frame_t)];
 
 	for (int i = startFrame; i < endFrame; i++)

--- a/addons/sourcemod/scripting/surftimer/replay.sp
+++ b/addons/sourcemod/scripting/surftimer/replay.sp
@@ -1035,6 +1035,8 @@ public void PlayReplay(int client, int &buttons, int &subtype, int &seed, int &i
 		// We're supposed to teleport stuff?
 		if (iFrame.AdditionalFields & (ADDITIONAL_FIELD_TELEPORTED_ORIGIN | ADDITIONAL_FIELD_TELEPORTED_ANGLES | ADDITIONAL_FIELD_TELEPORTED_VELOCITY))
 		{
+			AdditionalTeleport iAT;
+			ArrayList hAdditionalTeleport;
 			char sPath[PLATFORM_MAX_PATH];
 			if (client == g_RecordBot)
 			{
@@ -1070,13 +1072,10 @@ public void PlayReplay(int client, int &buttons, int &subtype, int &seed, int &i
 			BuildPath(Path_SM, sPath, sizeof(sPath), "%s", sPath);
 			if (g_smLoadedRecordsAdditionalTeleport != null)
 			{
-				AdditionalTeleport iAT;
-				ArrayList hAdditionalTeleport = null;
 				g_smLoadedRecordsAdditionalTeleport.GetValue(sPath, hAdditionalTeleport);
 				if (hAdditionalTeleport != null)
 				{
 					hAdditionalTeleport.GetArray(g_CurrentAdditionalTeleportIndex[client], iAT, 10);
-					delete hAdditionalTeleport;
 				}
 
 				float fOrigin[3], fAngles[3], fVelocity[3];

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -682,6 +682,8 @@ public void sql_CalcuatePlayerRankCallback(Handle owner, Handle hndl, const char
 
 			CalculatePlayerRank(client, style);
 		}
+
+		CloseHandle(pack);
 	}
 }
 

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -650,6 +650,8 @@ public void sql_CalcuatePlayerRankCallback(Handle owner, Handle hndl, const char
 	}
 	else
 	{
+		CloseHandle(pack);
+		
 		// Players first time on server
 		if (client <= MaxClients)
 		{
@@ -682,8 +684,6 @@ public void sql_CalcuatePlayerRankCallback(Handle owner, Handle hndl, const char
 
 			CalculatePlayerRank(client, style);
 		}
-
-		CloseHandle(pack);
 	}
 }
 

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -3106,7 +3106,7 @@ public void SQL_LastRunCallback(Handle owner, Handle hndl, const char[] error, a
 		// Set new start time
 		float fl_time = SQL_FetchFloat(hndl, 6);
 		int tickrate = RoundFloat(float(SQL_FetchInt(hndl, 7)) / 5.0 / 11.0);
-		if (tickrate == g_Server_Tickrate)
+		if (tickrate == g_iTickrate)
 		{
 			if (fl_time > 0.0)
 			{
@@ -4734,7 +4734,7 @@ public void db_insertLastPositionCallback(Handle owner, Handle hndl, const char[
 	{
 		if (!g_bTimerRunning[client])
 		g_fPlayerLastTime[client] = -1.0;
-		int tickrate = g_Server_Tickrate * 5 * 11;
+		int tickrate = g_iTickrate * 5 * 11;
 		if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 		{
 			Format(szQuery, 1024, sql_updatePlayerTmp, g_fPlayerCordsLastPosition[client][0], g_fPlayerCordsLastPosition[client][1], g_fPlayerCordsLastPosition[client][2], g_fPlayerAnglesLastPosition[client][0], g_fPlayerAnglesLastPosition[client][1], g_fPlayerAnglesLastPosition[client][2], g_fPlayerLastTime[client], szMapName, tickrate, stage, zgroup, szSteamID);

--- a/addons/sourcemod/scripting/surftimer/timer.sp
+++ b/addons/sourcemod/scripting/surftimer/timer.sp
@@ -216,7 +216,7 @@ public Action CKTimer2(Handle timer)
 			g_bOverlay[i] = false;
 
 		// stop replay to prevent server crashes because of a massive recording array (max. 2h)
-		if (g_hRecording[i] != null && g_fCurrentRunTime[i] > 6720.0)
+		if (g_aRecording[i] != null && g_fCurrentRunTime[i] > 6720.0)
 		{
 			StopRecording(i);
 		}
@@ -491,18 +491,6 @@ public Action CenterMsgTimer(Handle timer, any client)
 		g_bRestorePositionMsg[client] = false;
 	}
 
-	return Plugin_Handled;
-}
-
-public Action RemoveRagdoll(Handle timer, any victim)
-{
-	if (IsValidEntity(victim) && !IsPlayerAlive(victim))
-	{
-		int player_ragdoll;
-		player_ragdoll = GetEntDataEnt2(victim, g_ragdolls);
-		if (player_ragdoll != -1)
-			RemoveEdict(player_ragdoll);
-	}
 	return Plugin_Handled;
 }
 


### PR DESCRIPTION
Sometimes the bots bug when a player cuts a trigger/wall too close, and it has been bothering us for a long time:rage:
Also, this problem can be traced back to the time since cksurf use **velocity** and **angle** to store our replay
(pretty worse legacy:joy:)

some like #20 #98 point it out directly but no one solve.

This PR cost me a half day, and here's what i'm mainly doing

- Replace the function with methodmap
- **Support the old replay** version(0x01) while using the new version(0x02)
- Write and load new replay based on **position** and **angle**:blush::blush::blush:
- Delete useless(unused) sentences and improve something

**I haven't done enough testing yet**, may have bugs
but hope that there's something change since this pr :persevere::persevere::persevere:.