### PR TITLE
Disable practice mode when player touches a map/bonus start zone.

### DIFF
--- a/addons/sourcemod/scripting/surftimer/surfzones.sp
+++ b/addons/sourcemod/scripting/surftimer/surfzones.sp
@@ -334,6 +334,12 @@ public void StartTouch(int client, int action[3])
 			lastCheckpoint[g_iClientInZone[client][2]][client] = 1;
 			g_bSaveLocTele[client] = false;
 
+			if (g_bPracticeMode[client])
+			{
+				g_bPracticeMode[client] = false;
+				CPrintToChat(client, "%t", "PracticeNormal", g_szChatPrefix);
+			}
+
 			if (g_bhasStages)
 			{
 				g_bWrcpTimeractivated[client] = false;
@@ -579,12 +585,6 @@ public void EndTouch(int client, int action[3])
 		// Types: Start(1), End(2), Stage(3), Checkpoint(4), Speed(5), TeleToStart(6), Validator(7), Chekcer(8), Stop(0)
 		if (action[0] == 1 || action[0] == 5)
 		{	
-			if (g_bPracticeMode[client] && !g_bTimerRunning[client]) // If on practice mode, but timer isn't on - kick you out of practice mode and then start timer 
-			{
-				g_bPracticeMode[client] = false;
-				CPrintToChat(client, "%t", "PracticeNormal", g_szChatPrefix);
-			}
-			
 			if (!g_bPracticeMode[client])
 			{
 				g_Stage[g_iClientInZone[client][2]][client] = 1;


### PR DESCRIPTION
Currently, the timer disables Practice Mode for a player only when they exit the start zone. This has left room for an exploit in the current release that allows players to bypass limitations placed in the start-zone as a result of still being in Practice Mode after failing. 

Since `g_bPracticeMode[client]` is still true when a player is in the start-zone after failing, they can bypass the prespeed limiter and prehop infinitely to give themselves a massive advantage. (i.e, players can enter practice mode, fail by hitting a reset trigger, and then prehop infinitely in the start zone.)

This pull request turns off Practice Mode for a player when they enter a start zone rather than when they exit one. This prevents the above exploit from being possible.