### PR TITLE
Disable playerradio and ping radio commands

### DIFF
--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -1549,7 +1549,7 @@ char RadioCMDS[][] =  // Disable radio commands
 	"coverme", "takepoint", "holdpos", "regroup", "followme", "takingfire", "go", "fallback", "sticktog",
 	"getinpos", "stormfront", "report", "roger", "enemyspot", "needbackup", "sectorclear", "inposition",
 	"reportingin", "getout", "negative", "enemydown", "cheer", "thanks", "nice", "compliment", "go_a",
-	"go_b", "sorry", "needrop"
+	"go_b", "sorry", "needrop", "playerradio", "playerchatwheel", "chatwheel_ping", "player_ping"
 };
 
 /*======  End of Declarations  ======*/


### PR DESCRIPTION
Added a few radio commands to block. Mainly gets rid of pings, chatwheel commands, and the moaning radio command.