### PR TITLE
fix hud cant be disabled when player's dead

### DIFF
--- a/addons/sourcemod/scripting/surftimer/convars.sp
+++ b/addons/sourcemod/scripting/surftimer/convars.sp
@@ -458,7 +458,7 @@ void CreateConVars()
 
 	// New noclip
 	sv_noclipspeed = FindConVar("sv_noclipspeed");
-	sv_noclipspeed.Flags &= ~FCVAR_NOTIFY;
+	sv_noclipspeed.Flags &= ~(FCVAR_NOTIFY | FCVAR_REPLICATED);
 	g_iDefaultNoclipSpeed = sv_noclipspeed.FloatValue;
 	for(int i = 1; i <= MaxClients; i++)
 	{

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -1300,8 +1300,8 @@ public void SetClientDefaults(int client)
 
 	g_ClientRenamingZone[client] = false;
 
-	g_bNewReplay[client] = false;
-	g_bNewBonus[client] = false;
+	g_bSavingReplay[client] = false;
+	g_bHijackFrame[client] = false;
 
 	g_bFirstTimerStart[client] = true;
 	g_pr_Calculating[client] = false;
@@ -1394,9 +1394,6 @@ public void SetClientDefaults(int client)
 	// VIP
 	g_bCheckCustomTitle[client] = false;
 	g_bZoner[client] = false;
-
-	// WRCP Replays
-	g_bSavingWrcpReplay[client] = false;
 
 	// Reset Bonus Bool
 	g_bInBonus[client] = false;
@@ -3276,17 +3273,41 @@ public void CenterHudDead(int client)
 
 			if (IsFakeClient(ObservedUser))
 			{
-				if (ObservedUser == g_RecordBot)
-					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szReplayTime);
-				else if (ObservedUser == g_BonusBot)
-					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szBonusTime);
-				else if (ObservedUser == g_WrcpBot)
-					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szWrcpReplayTime[g_iCurrentlyPlayingStage]);
-
 				float fSpeed[3];
 				GetEntPropVector(ObservedUser, Prop_Data, "m_vecVelocity", fSpeed);
 
 				float fSpeedHUD = SquareRoot(Pow(fSpeed[0], 2.0) + Pow(fSpeed[1], 2.0));
+
+				if (ObservedUser == g_RecordBot)
+				{
+					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szReplayTime);
+
+					if(g_iSelectedReplayStyle == 5)
+					{
+						fSpeedHUD /= 0.5;
+					}
+					else if(g_iSelectedReplayStyle == 6)
+					{
+						fSpeedHUD /= 1.5;
+					}
+				}
+				else if (ObservedUser == g_BonusBot)
+				{
+					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szBonusTime);
+
+					if(g_iSelectedBonusReplayStyle == 5)
+					{
+						fSpeedHUD /= 0.5;
+					}
+					else if(g_iSelectedBonusReplayStyle == 6)
+					{
+						fSpeedHUD /= 1.5;
+					}
+				}
+				else if (ObservedUser == g_WrcpBot)
+				{
+					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szWrcpReplayTime[g_iCurrentlyPlayingStage]);
+				}
 
 				PrintCSGOHUDText(client, "<pre>%s\nSpeed: <font color='#5e5'>%i u/s\n%s</pre>", obsAika, RoundToNearest(fSpeedHUD), sResult);
 				return;
@@ -4894,31 +4915,4 @@ public void PrintPracSrcp(int client, int style, int stage, float fClientPbStage
 	}
 
 	CheckpointToSpec(client, szSpecMessage);
-}
-
-int GivePlayerWeaponAndSkin(int client, const char[] name, int team)
-{
-	int currentTeam = GetEntProp(client, Prop_Data, "m_iTeamNum");
-	if (currentTeam != team)
-	{
-		SetEntProp(client, Prop_Data, "m_iTeamNum", team);
-	}
-
-	int weapon = GivePlayerItem(client, name);
-
-	if (currentTeam != team)
-	{
-		SetEntProp(client, Prop_Data, "m_iTeamNum", currentTeam);
-	}
-
-	return weapon;
-}
-
-void SafeDropWeapon(int client, int slot)
-{
-	int weapon = GetPlayerWeaponSlot(client, slot);
-	if (weapon != -1)
-	{
-		RemoveEntity(weapon);
-	}
 }

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -3283,7 +3283,12 @@ public void CenterHudDead(int client)
 				else if (ObservedUser == g_WrcpBot)
 					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szWrcpReplayTime[g_iCurrentlyPlayingStage]);
 
-				PrintCSGOHUDText(client, "<pre>%s\nSpeed: <font color='#5e5'>%i u/s\n%s</pre>", obsAika, RoundToNearest(g_fLastSpeed[ObservedUser]), sResult);
+				float fSpeed[3];
+				GetEntPropVector(ObservedUser, Prop_Data, "m_vecVelocity", fSpeed);
+
+				float fSpeedHUD = SquareRoot(Pow(fSpeed[0], 2.0) + Pow(fSpeed[1], 2.0));
+
+				PrintCSGOHUDText(client, "<pre>%s\nSpeed: <font color='#5e5'>%i u/s\n%s</pre>", obsAika, RoundToNearest(fSpeedHUD), sResult);
 				return;
 			}
 			else if (g_bTimerRunning[ObservedUser])

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -3276,17 +3276,41 @@ public void CenterHudDead(int client)
 
 			if (IsFakeClient(ObservedUser))
 			{
-				if (ObservedUser == g_RecordBot)
-					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szReplayTime);
-				else if (ObservedUser == g_BonusBot)
-					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szBonusTime);
-				else if (ObservedUser == g_WrcpBot)
-					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szWrcpReplayTime[g_iCurrentlyPlayingStage]);
-
 				float fSpeed[3];
 				GetEntPropVector(ObservedUser, Prop_Data, "m_vecVelocity", fSpeed);
 
 				float fSpeedHUD = SquareRoot(Pow(fSpeed[0], 2.0) + Pow(fSpeed[1], 2.0));
+
+				if (ObservedUser == g_RecordBot)
+				{
+					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szReplayTime);
+
+					if(g_iSelectedReplayStyle == 5)
+					{
+						fSpeedHUD /= 0.5;
+					}
+					else if(g_iSelectedReplayStyle == 6)
+					{
+						fSpeedHUD /= 1.5;
+					}
+				}
+				else if (ObservedUser == g_BonusBot)
+				{
+					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szBonusTime);
+
+					if(g_iSelectedBonusReplayStyle == 5)
+					{
+						fSpeedHUD /= 0.5;
+					}
+					else if(g_iSelectedBonusReplayStyle == 6)
+					{
+						fSpeedHUD /= 1.5;
+					}
+				}
+				else if (ObservedUser == g_WrcpBot)
+				{
+					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szWrcpReplayTime[g_iCurrentlyPlayingStage]);
+				}
 
 				PrintCSGOHUDText(client, "<pre>%s\nSpeed: <font color='#5e5'>%i u/s\n%s</pre>", obsAika, RoundToNearest(fSpeedHUD), sResult);
 				return;

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -1300,8 +1300,8 @@ public void SetClientDefaults(int client)
 
 	g_ClientRenamingZone[client] = false;
 
-	g_bSavingReplay[client] = false;
-	g_bHijackFrame[client] = false;
+	g_bNewReplay[client] = false;
+	g_bNewBonus[client] = false;
 
 	g_bFirstTimerStart[client] = true;
 	g_pr_Calculating[client] = false;
@@ -1394,6 +1394,9 @@ public void SetClientDefaults(int client)
 	// VIP
 	g_bCheckCustomTitle[client] = false;
 	g_bZoner[client] = false;
+
+	// WRCP Replays
+	g_bSavingWrcpReplay[client] = false;
 
 	// Reset Bonus Bool
 	g_bInBonus[client] = false;
@@ -3273,41 +3276,17 @@ public void CenterHudDead(int client)
 
 			if (IsFakeClient(ObservedUser))
 			{
+				if (ObservedUser == g_RecordBot)
+					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szReplayTime);
+				else if (ObservedUser == g_BonusBot)
+					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szBonusTime);
+				else if (ObservedUser == g_WrcpBot)
+					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szWrcpReplayTime[g_iCurrentlyPlayingStage]);
+
 				float fSpeed[3];
 				GetEntPropVector(ObservedUser, Prop_Data, "m_vecVelocity", fSpeed);
 
 				float fSpeedHUD = SquareRoot(Pow(fSpeed[0], 2.0) + Pow(fSpeed[1], 2.0));
-
-				if (ObservedUser == g_RecordBot)
-				{
-					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szReplayTime);
-
-					if(g_iSelectedReplayStyle == 5)
-					{
-						fSpeedHUD /= 0.5;
-					}
-					else if(g_iSelectedReplayStyle == 6)
-					{
-						fSpeedHUD /= 1.5;
-					}
-				}
-				else if (ObservedUser == g_BonusBot)
-				{
-					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szBonusTime);
-
-					if(g_iSelectedBonusReplayStyle == 5)
-					{
-						fSpeedHUD /= 0.5;
-					}
-					else if(g_iSelectedBonusReplayStyle == 6)
-					{
-						fSpeedHUD /= 1.5;
-					}
-				}
-				else if (ObservedUser == g_WrcpBot)
-				{
-					Format(obsAika, sizeof(obsAika), "<font color='#ec8'>%s</font>", g_szWrcpReplayTime[g_iCurrentlyPlayingStage]);
-				}
 
 				PrintCSGOHUDText(client, "<pre>%s\nSpeed: <font color='#5e5'>%i u/s\n%s</pre>", obsAika, RoundToNearest(fSpeedHUD), sResult);
 				return;
@@ -4915,4 +4894,31 @@ public void PrintPracSrcp(int client, int style, int stage, float fClientPbStage
 	}
 
 	CheckpointToSpec(client, szSpecMessage);
+}
+
+int GivePlayerWeaponAndSkin(int client, const char[] name, int team)
+{
+	int currentTeam = GetEntProp(client, Prop_Data, "m_iTeamNum");
+	if (currentTeam != team)
+	{
+		SetEntProp(client, Prop_Data, "m_iTeamNum", team);
+	}
+
+	int weapon = GivePlayerItem(client, name);
+
+	if (currentTeam != team)
+	{
+		SetEntProp(client, Prop_Data, "m_iTeamNum", currentTeam);
+	}
+
+	return weapon;
+}
+
+void SafeDropWeapon(int client, int slot)
+{
+	int weapon = GetPlayerWeaponSlot(client, slot);
+	if (weapon != -1)
+	{
+		RemoveEntity(weapon);
+	}
 }

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -2911,6 +2911,11 @@ public void AutoBhopFunction(int client, int &buttons)
 
 public void SpecListMenuDead(int client) // What Spectators see
 {
+	if(!g_bSideHud[client])
+	{
+		return;
+	}
+
 	char szTick[32];
 	Format(szTick, 32, "%i", g_iTickrate);
 	int ObservedUser;
@@ -3223,6 +3228,11 @@ public void SetInfoBotName(int ent)
 
 public void CenterHudDead(int client)
 {
+	if(!g_bCentreHud[client])
+	{
+		return;
+	}
+
 	char szTick[32];
 	char obsAika[128];
 	float obsTimer;


### PR DESCRIPTION
player can not disable their hud when dead, even if they already set their timer's sidehud or centre hud to **[OFF]**