### PR TITLE
Resolve #114 - Update LimitMaxSpeed in hooks to use the correct MaxSpeed value

### DIFF
--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -899,7 +899,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	}
 	else if (g_bInMaxSpeed[client])
 	{
-		LimitMaxSpeed(client, 2500.0);
+		LimitMaxSpeed(client, g_mapZones[g_iClientInZone[client][3]].PreSpeed);
 	}
 
 	/*------ Styles ------*/


### PR DESCRIPTION
To resolve #114,

This PR implements what @timyc mentioned in the above issue. It allows zoners to use Max Speed zones and takes into account the actual speed set. 

From my testing, this also seems to make MaxSpeed zones work when they didn't before.
Here's a quick video of me testing it: [Streamable](https://streamable.com/c02cc5)
