### PR TITLE
Reset SelectedReplayStyle variables in automatic replay loop

### DIFF
--- a/addons/sourcemod/scripting/surftimer/replay.sp
+++ b/addons/sourcemod/scripting/surftimer/replay.sp
@@ -1199,6 +1199,7 @@ static void LoopReplay(int client)
 					g_iManualBonusReplayCount = 0;
 					g_bManualBonusReplayPlayback = false;
 					g_iCurrentBonusReplayIndex = 0;
+					g_iSelectedBonusReplayStyle = 0;
 					PlayRecord(g_BonusBot, 1, 0);
 					g_iClientInZone[g_BonusBot][2] = g_iBonusToReplay[g_iCurrentBonusReplayIndex];
 				}
@@ -1215,6 +1216,7 @@ static void LoopReplay(int client)
 					g_iCurrentBonusReplayIndex = 0;
 				}
 
+				g_iSelectedBonusReplayStyle = 0;
 				PlayRecord(g_BonusBot, 1, 0);
 				g_iClientInZone[g_BonusBot][2] = g_iBonusToReplay[g_iCurrentBonusReplayIndex];
 			}
@@ -1231,6 +1233,7 @@ static void LoopReplay(int client)
 				{
 					g_iManualReplayCount = 0;
 					g_bManualReplayPlayback = false;
+					g_iSelectedReplayStyle = 0;
 					PlayRecord(g_RecordBot, 0, 0);
 				}
 			}


### PR DESCRIPTION
Since PR #325, the replays system relies on the `g_iSelectedReplayStyle` and `g_iSelectedBonusReplayStyle` variables to determine what style the current replay bot is in to correctly calculate and display the bot's speed.

These variables are only set when a player uses the `sm_replay` command. However, after the system is done showing the replay to the player, it returns back to the default replay bot (or in the cases of bonuses, cycles through replays for each bonus). These are all in normal style, but since those style variables are never reset, the speed on those bots are entirely wrong if someone were to spectate the bots casually without using `sm_replay`.

This PR just makes sure those two variables are correctly reset before the bots cycle back to the usual replays after showing the requested style replay to the player.