### PR TITLE
Use the correct colorvariables include file in workflows

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Fetch plugin dependencies
         run: |
           wget https://raw.githubusercontent.com/bcserv/smlib/transitional_syntax/scripting/include/smlib.inc -P $INCLUDE_PATH
-          wget https://raw.githubusercontent.com/PremyslTalich/ColorVariables/master/addons/sourcemod/scripting/includes/colorvariables.inc -P $INCLUDE_PATH
+          wget https://raw.githubusercontent.com/olokos/Chat-Processor/master/scripting/include/colorvariables.inc -P $INCLUDE_PATH
           wget https://raw.githubusercontent.com/KyleSanderson/SteamWorks/master/Pawn/includes/SteamWorks.inc -P $INCLUDE_PATH
           wget https://raw.githubusercontent.com/JoinedSenses/SourceMod-IncludeLibrary/master/include/smjansson.inc -P $INCLUDE_PATH
           wget https://raw.githubusercontent.com/peace-maker/DHooks2/dynhooks/sourcemod_files/scripting/include/dhooks.inc -P $INCLUDE_PATH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Fetch plugin dependencies
         run: |
           wget https://raw.githubusercontent.com/bcserv/smlib/transitional_syntax/scripting/include/smlib.inc -P $INCLUDE_PATH
-          wget https://raw.githubusercontent.com/PremyslTalich/ColorVariables/master/addons/sourcemod/scripting/includes/colorvariables.inc -P $INCLUDE_PATH
+          wget https://raw.githubusercontent.com/olokos/Chat-Processor/master/scripting/include/colorvariables.inc -P $INCLUDE_PATH
           wget https://raw.githubusercontent.com/KyleSanderson/SteamWorks/master/Pawn/includes/SteamWorks.inc -P $INCLUDE_PATH
           wget https://raw.githubusercontent.com/JoinedSenses/SourceMod-IncludeLibrary/master/include/smjansson.inc -P $INCLUDE_PATH
           wget https://raw.githubusercontent.com/peace-maker/DHooks2/dynhooks/sourcemod_files/scripting/include/dhooks.inc -P $INCLUDE_PATH


### PR DESCRIPTION
SurfTImer requires these to be defined:

```cpp
// Additional color names for ckSurf backwards compatibility
SetTrieString(hTrie, "bluegray", "\x0A"); // using bluegrey
SetTrieString(hTrie, "gray", "\x08"); // using gray
SetTrieString(hTrie, "gray2", "\x0D"); // using gray2
SetTrieString(hTrie, "orange", "\x10"); // using gold
SetTrieString(hTrie, "steelblue", "\x0D"); // using grey2
SetTrieString(hTrie, "pink", "\x0E"); // using orchid
SetTrieString(hTrie, "lightblue", "\x0A"); // using bluegrey
SetTrieString(hTrie, "olive", "\x05"); // using lightgreen
```

Just correcting the workflows to use the right include file for colors (to be more specific, this PR makes it use the one linked in the compile requirements in the README.)