### PR TITLE
LimitMaxSpeed only when zoneID is not below zero, attempt to resolve #350

### DIFF
--- a/addons/sourcemod/scripting/surftimer/hooks.sp
+++ b/addons/sourcemod/scripting/surftimer/hooks.sp
@@ -899,7 +899,8 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	}
 	else if (g_bInMaxSpeed[client])
 	{
-		LimitMaxSpeed(client, g_mapZones[g_iClientInZone[client][3]].PreSpeed);
+		if (g_iClientInZone[client][3] >= 0)
+			LimitMaxSpeed(client, g_mapZones[g_iClientInZone[client][3]].PreSpeed);
 	}
 
 	/*------ Styles ------*/


### PR DESCRIPTION
I've talked briefly about this in #350 - this pull request adds a simple check to ensure that the zoneID is valid before attempting to limit speed when the player is in a MaxSpeed zone.