### PR TITLE
Replace SQL_GetRowCount with SQL_FetchInt in SQL_ViewAllRecordsCallba…

### DIFF
--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -2943,7 +2943,7 @@ public void SQL_ViewTop10RecordsCallback2(Handle owner, Handle hndl, const char[
 		char szSteamId[32];
 		char szMapName[128];
 
-		int rank = SQL_GetRowCount(hndl);
+		int rank = SQL_FetchInt(hndl, 0);
 		WritePackCell(data, rank);
 		ResetPack(data);
 		ReadPackString(data, szName, MAX_NAME_LENGTH);


### PR DESCRIPTION
…ck2 in sql.sp

This should allow the ranks to show up correctly rather than showing everyone as rank 1 when searching their completed maps.