### PR TITLE
Add a new stock for clarity and remove an old stock

### DIFF
--- a/addons/sourcemod/scripting/surftimer/buttonpress.sp
+++ b/addons/sourcemod/scripting/surftimer/buttonpress.sp
@@ -12,7 +12,7 @@ public void CL_OnStartTimerPress(int client)
 				if (fGetGameTime - g_fErrorMessage[client] > 1.0)
 				{
 					CPrintToChat(client, "%t", "BPress1", g_szChatPrefix);
-					ClientCommand(client, "play buttons\\button10.wav");
+					EmitSoundToClientNoPreCache(client, "play buttons\\button10.wav", false);
 					g_fErrorMessage[client] = fGetGameTime;
 				}
 				return;
@@ -22,7 +22,7 @@ public void CL_OnStartTimerPress(int client)
 				if (fGetGameTime - g_fErrorMessage[client] > 1.0)
 				{
 					CPrintToChat(client, "%t", "BPress2", g_szChatPrefix);
-					ClientCommand(client, "play buttons\\button10.wav");
+					EmitSoundToClientNoPreCache(client, "play buttons\\button10.wav", false);
 					g_fErrorMessage[client] = fGetGameTime;
 				}
 				return;
@@ -32,7 +32,7 @@ public void CL_OnStartTimerPress(int client)
 				if (fGetGameTime - g_fErrorMessage[client] > 1.0)
 				{
 					CPrintToChat(client, "%t", "BPress3", g_szChatPrefix);
-					ClientCommand(client, "play buttons\\button10.wav");
+					EmitSoundToClientNoPreCache(client, "play buttons\\button10.wav", false);
 					g_fErrorMessage[client] = fGetGameTime;
 				}
 				return;
@@ -176,7 +176,7 @@ public void CL_OnEndTimerPress(int client)
 	// If timer is not on, play error sound and return
 	if (!g_bTimerRunning[client])
 	{
-		ClientCommand(client, "play buttons\\button10.wav");
+		EmitSoundToClientNoPreCache(client, "play buttons\\button10.wav", false);
 		return;
 	}
 	else

--- a/addons/sourcemod/scripting/surftimer/commands.sp
+++ b/addons/sourcemod/scripting/surftimer/commands.sp
@@ -1326,7 +1326,7 @@ public Action Command_Restart(int client, int args)
 			g_fClientRestarting[client] = GetGameTime();
 			g_bClientRestarting[client] = true;
 			CPrintToChat(client, "%t", "Commands34", g_szChatPrefix);
-			ClientCommand(client, "play ambient/misc/clank4");
+			EmitSoundToClientNoPreCache(client, "play ambient/misc/clank4", false);
 			return Plugin_Handled;
 		}
 	}

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -1124,8 +1124,7 @@ public void PlayButtonSound(int client)
 	{
 		char buffer[255];
 		GetConVarString(g_hSoundPath, buffer, 255);
-		Format(buffer, sizeof(buffer), "play %s", buffer);
-		ClientCommand(client, buffer);
+		EmitSoundToClientNoPreCache(client, buffer);
 	}
 
 	// Spectators button sound
@@ -1141,8 +1140,7 @@ public void PlayButtonSound(int client)
 				{
 					char szsound[255];
 					GetConVarString(g_hSoundPath, szsound, 256);
-					Format(szsound, sizeof(szsound), "play %s", szsound);
-					ClientCommand(i, szsound);
+					EmitSoundToClientNoPreCache(client, szsound);
 				}
 			}
 		}
@@ -1535,8 +1533,7 @@ public void PlayRecordSound(int iRecordtype)
 		{
 			if (IsValidClient(i) && !IsFakeClient(i) && g_bEnableQuakeSounds[i] == true)
 			{
-				Format(buffer, sizeof(buffer), "play %s", g_szRelativeSoundPathWR);
-				ClientCommand(i, buffer);
+				EmitSoundToClientNoPreCache(i, buffer);
 			}
 		}
 	}
@@ -1546,8 +1543,7 @@ public void PlayRecordSound(int iRecordtype)
 		{
 			if (IsValidClient(i) && !IsFakeClient(i) && g_bEnableQuakeSounds[i] == true)
 			{
-				Format(buffer, sizeof(buffer), "play %s", g_szRelativeSoundPathWR);
-				ClientCommand(i, buffer);
+				EmitSoundToClientNoPreCache(i, buffer);
 			}
 		}
 	}
@@ -1557,8 +1553,7 @@ public void PlayRecordSound(int iRecordtype)
 		{
 			if (IsValidClient(i) && !IsFakeClient(i) && g_bEnableQuakeSounds[i] == true)
 			{
-				Format(buffer, sizeof(buffer), "play %s", g_szRelativeSoundPathTop);
-				ClientCommand(i, buffer);
+				EmitSoundToClientNoPreCache(i, buffer);
 			}
 		}
 	}
@@ -1568,8 +1563,7 @@ public void PlayRecordSound(int iRecordtype)
 		{
 			if (IsValidClient(i) && !IsFakeClient(i) && g_bEnableQuakeSounds[i] == true)
 			{
-				Format(buffer, sizeof(buffer), "play %s", g_szRelativeSoundPathTop);
-				ClientCommand(i, buffer);
+				EmitSoundToClientNoPreCache(i, buffer);
 			}
 		}
 	}
@@ -1577,10 +1571,10 @@ public void PlayRecordSound(int iRecordtype)
 
 public void PlayUnstoppableSound(int client)
 {
-	char buffer[255];
-	Format(buffer, sizeof(buffer), "play %s", g_szRelativeSoundPathPB);
 	if (!IsFakeClient(client) && g_bEnableQuakeSounds[client])
-		ClientCommand(client, buffer);
+	{
+		EmitSoundToClientNoPreCache(client, g_szRelativeSoundPathPB);
+	}
 	// Spec Stop Sound
 	for (int i = 1; i <= MaxClients; i++)
 	{
@@ -1591,7 +1585,9 @@ public void PlayUnstoppableSound(int client)
 			{
 				int Target = GetEntPropEnt(i, Prop_Send, "m_hObserverTarget");
 				if (Target == client && g_bEnableQuakeSounds[i])
-					ClientCommand(i, buffer);
+				{
+					EmitSoundToClientNoPreCache(i, g_szRelativeSoundPathPB);
+				}
 			}
 		}
 	}
@@ -1604,8 +1600,7 @@ public void PlayWRCPRecord()
 	{
 		if (IsValidClient(i) && !IsFakeClient(i) && g_bEnableQuakeSounds[i] == true)
 		{
-			Format(buffer, sizeof(buffer), "play %s", g_szRelativeSoundPathWRCP);
-			ClientCommand(i, buffer);
+			EmitSoundToClientNoPreCache(i, buffer);
 		}
 	}
 }
@@ -2811,25 +2806,6 @@ public bool TraceRayDontHitSelf(int entity, int mask, any data)
 stock int BooltoInt(bool status)
 {
 	return (status) ? 1:0;
-}
-
-public void PlayQuakeSound_Spec(int client, char[] buffer)
-{
-	int SpecMode;
-	for (int x = 1; x <= MaxClients; x++)
-	{
-		if (IsValidClient(x) && !IsPlayerAlive(x))
-		{
-			SpecMode = GetEntProp(x, Prop_Send, "m_iObserverMode");
-			if (SpecMode == 4 || SpecMode == 5)
-			{
-				int Target = GetEntPropEnt(x, Prop_Send, "m_hObserverTarget");
-				if (Target == client)
-					if (g_bEnableQuakeSounds[x])
-					ClientCommand(x, buffer);
-			}
-		}
-	}
 }
 
 public void AttackProtection(int client, int &buttons)
@@ -5336,4 +5312,27 @@ void RemoveColors(char[] message, int maxlength)
 {
 	CRemoveTags(message, maxlength);
 	CRemoveColors(message, maxlength);
+}
+
+
+/**
+ * Emit a sound to a client without having to precache the sound.
+ * See https://wiki.alliedmods.net/Csgo_quirks#The_.22play.22_client_command for more details.
+ * 
+ * @param client      The client's id.
+ * @param szPath      The path of the sound with or without "play " as a suffix.
+ * @param addPlay     Whether or not "play " should be append to the begining of szPath (default = true).
+ */
+stock void EmitSoundToClientNoPreCache(int client, const char[] szPath, bool addPlay = true)
+{
+	char szBuffer[256];
+	if(addPlay)
+	{
+		Format(szBuffer, sizeof szBuffer, "play %s", szPath);
+	}
+	else
+	{
+		strcopy(szBuffer, sizeof szBuffer, szPath);
+	}
+	ClientCommand(client, szBuffer);
 }

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -4920,11 +4920,11 @@ stock void SendNewRecordForward(int client, const char[] szRecordDiff, int bonus
  * Sends a new WRCP forward on surftimer_OnNewWRCP.
  * 
  * @param client           Index of the client.
- * @param client           ID of the stage.
+ * @param stage            ID of the stage.
  * @param szRecordDiff     String containing the formatted difference with the previous record.
  */
- stock void SendNewWRCPForward(int client, int stage, const char[] szRecordDiff)
- {
+stock void SendNewWRCPForward(int client, int stage, const char[] szRecordDiff)
+{
 	/* Start New record function call */
 	Call_StartForward(g_NewWRCPForward);
 
@@ -4937,7 +4937,9 @@ stock void SendNewRecordForward(int client, const char[] szRecordDiff, int bonus
 
 	/* Finish the call, get the result */
 	Call_Finish();
- }
+}
+
+
 bool CGetColor(const char[] sName, char[] sColor, int iColorSize)
 {
 	if (sName[0] == '\0')

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -6150,9 +6150,15 @@ public void SQL_UpdateWrcpRecordCallback2(Handle owner, Handle hndl, const char[
 	FormatTimeFloat(client, f_srDiff, 3, sz_srRawDiff, 128);
 
 	if (f_srDiff > 0)
+	{
 		Format(sz_srDiff, 128, "%cSR: %c-%s%c", WHITE, LIGHTGREEN, sz_srRawDiff, WHITE);
+		Format(sz_srRawDiff, sizeof sz_srRawDiff, "-%s", sz_srRawDiff);
+	}
 	else
+	{
 		Format(sz_srDiff, 128, "%cSR: %c+%s%c", WHITE, RED, sz_srRawDiff, WHITE);
+		Format(sz_srRawDiff, sizeof sz_srRawDiff, "+%s", sz_srRawDiff);
+	}
 
 	// Check for SR
 	bool newRecordHolder = false;

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -6119,6 +6119,7 @@ public void SQL_UpdateWrcpRecordCallback2(Handle owner, Handle hndl, const char[
 	GetClientName(client, szName, MAX_NAME_LENGTH);
 
 	char sz_srDiff[128];
+	char sz_srRawDiff[128];
 
 	// PB
 	char szDiff[128];
@@ -6146,12 +6147,12 @@ public void SQL_UpdateWrcpRecordCallback2(Handle owner, Handle hndl, const char[
 	else if (style != 0)
 		f_srDiff = (g_fStyleStageRecord[style][stage] - time);
 
-	FormatTimeFloat(client, f_srDiff, 3, sz_srDiff, 128);
+	FormatTimeFloat(client, f_srDiff, 3, sz_srRawDiff, 128);
 
 	if (f_srDiff > 0)
-		Format(sz_srDiff, 128, "%cSR: %c-%s%c", WHITE, LIGHTGREEN, sz_srDiff, WHITE);
+		Format(sz_srDiff, 128, "%cSR: %c-%s%c", WHITE, LIGHTGREEN, sz_srRawDiff, WHITE);
 	else
-		Format(sz_srDiff, 128, "%cSR: %c+%s%c", WHITE, RED, sz_srDiff, WHITE);
+		Format(sz_srDiff, 128, "%cSR: %c+%s%c", WHITE, RED, sz_srRawDiff, WHITE);
 
 	// Check for SR
 	bool newRecordHolder = false;
@@ -6173,7 +6174,7 @@ public void SQL_UpdateWrcpRecordCallback2(Handle owner, Handle hndl, const char[
 				g_bSavingWrcpReplay[client] = true;
 				// Stage_SaveRecording(client, stage, g_szFinalWrcpTime[client]);
 				PlayWRCPRecord();
-				SendNewWRCPForward(client, stage, sz_srDiff);
+				SendNewWRCPForward(client, stage, sz_srRawDiff);
 			}
 			else
 			{
@@ -6197,7 +6198,7 @@ public void SQL_UpdateWrcpRecordCallback2(Handle owner, Handle hndl, const char[
 			g_bSavingWrcpReplay[client] = true;
 			// Stage_SaveRecording(client, stage, g_szFinalWrcpTime[client]);
 			PlayWRCPRecord();
-			SendNewWRCPForward(client, stage, sz_srDiff);
+			SendNewWRCPForward(client, stage, sz_srRawDiff);
 		}
 	}
 	else if (style != 0) // styles
@@ -6218,7 +6219,7 @@ public void SQL_UpdateWrcpRecordCallback2(Handle owner, Handle hndl, const char[
 
 				CPrintToChatAll("%t", "SQL19", g_szChatPrefix, szName, g_szStyleRecordPrint[style], stage, g_szFinalWrcpTime[client], sz_srDiff, g_StyleStageRank[style][client][stage], g_TotalStageStyleRecords[style][stage]);
 				PlayWRCPRecord();
-				SendNewWRCPForward(client, stage, sz_srDiff);
+				SendNewWRCPForward(client, stage, sz_srRawDiff);
 			}
 			else
 			{
@@ -6240,7 +6241,7 @@ public void SQL_UpdateWrcpRecordCallback2(Handle owner, Handle hndl, const char[
 
 			CPrintToChatAll("%t", "SQL22", g_szChatPrefix, szName, g_szStyleRecordPrint[style], stage, g_szFinalWrcpTime[client]);
 			PlayWRCPRecord();
-			SendNewWRCPForward(client, stage, sz_srDiff);
+			SendNewWRCPForward(client, stage, sz_srRawDiff);
 		}
 	}
 

--- a/addons/sourcemod/scripting/surftimer/surfzones.sp
+++ b/addons/sourcemod/scripting/surftimer/surfzones.sp
@@ -594,7 +594,7 @@ public void EndTouch(int client, int action[3])
 				if (g_bNoClip[client] || (!g_bNoClip[client] && (GetGameTime() - g_fLastTimeNoClipUsed[client]) < 3.0))
 				{
 					CPrintToChat(client, "%t", "SurfZones1", g_szChatPrefix);
-					ClientCommand(client, "play buttons\\button10.wav");
+					EmitSoundToClientNoPreCache(client, "play buttons\\button10.wav", false);
 					// fluffys
 					// ClientCommand(client, "sm_stuck");
 				}


### PR DESCRIPTION
This PR adds a new stock `EmitSoundToClientNoPreCache` which allows to play a sound to a client without having to precache that sound.
This takes advantage of [this CSGO quirk](https://wiki.alliedmods.net/Csgo_quirks#The_.22play.22_client_command).
It was already implemented in the plugin, the PR just makes it more declarative through a stock.

```c
/**
 * Emit a sound to a client without having to precache the sound.
 * See https://wiki.alliedmods.net/Csgo_quirks#The_.22play.22_client_command for more details.
 * 
 * @param client      The client's id.
 * @param szPath      The path of the sound with or without "play " as a suffix.
 * @param addPlay     Whether or not "play " should be append to the begining of szPath (default = true).
 */
stock void EmitSoundToClientNoPreCache(int client, const char[] szPath, bool addPlay = true)
{
	char szBuffer[256];
	if(addPlay)
	{
		Format(szBuffer, sizeof szBuffer, "play %s", szPath);
	}
	else
	{
		strcopy(szBuffer, sizeof szBuffer, szPath);
	}
	ClientCommand(client, szBuffer);
}
```