### PR TITLE
Make times accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Yes, but not any more than other projects currently and for past years.
 * [AutoExecConfig](https://github.com/Impact123/AutoExecConfig)
 
 **SourceMod Plugins**
+* [End-Touch-Fix](https://github.com/rumourA/End-Touch-Fix) - Checks EntityUntouch on PostThink instead of server frames
 * *(recommended)* [Movement Unlocker](https://forums.alliedmods.net/showthread.php?t=255298) - Enables ground sliding
 * *(recommended)* [MomSurfFix](https://github.com/GAMMACASE/MomSurfFix) - Fixes ramp glitches
 * *(recommended)* [RNGFix](https://github.com/jason-e/rngfix) - Fixes a bunch of engine physics "bugs"
-* *(recommended)* [End-Touch-Fix](https://github.com/rumourA/End-Touch-Fix) - Checks EntityUntouch on PostThink instead of server frames
 * *(recommended)* [HeadBugFix](https://github.com/GAMMACASE/HeadBugFix) - Fixes the head boundary box poping up when you start ducking
 * *(recommended)* [PushFixDE](https://github.com/GAMMACASE/PushFixDE) - Fixes client prediction errors in push triggers
 * *(recommended)* [crouchboostfix](https://github.com/t5mat/crouchboostfix) - Prevents crouchboosting

--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -1635,6 +1635,15 @@ public void OnLibraryAdded(const char[] name)
 	}
 }
 
+public void OnAllPluginsLoaded()
+{
+	if (!LibraryExists("endtouchfix"))
+	{
+		SetFailState("Plugin \"End-Touch-Fix\" not loaded!");
+		return;
+	}
+}
+
 public void OnPluginEnd()
 {
 	// remove clan tags

--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -449,7 +449,6 @@ bool g_bWrcpEndZone[MAXPLAYERS + 1] = {false, ...};
 int g_CurrentStage[MAXPLAYERS + 1];
 float g_fStartWrcpTime[MAXPLAYERS + 1];
 float g_fFinalWrcpTime[MAXPLAYERS + 1];
-float g_fOldFinalWrcpTime[MAXPLAYERS + 1];
 
 // Total time the run took in 00:00:00 format
 char g_szFinalWrcpTime[MAXPLAYERS + 1][32];
@@ -1392,6 +1391,8 @@ int g_iTicksOnGround[MAXPLAYERS + 1];
 bool g_bNewStage[MAXPLAYERS + 1];
 bool g_bLeftZone[MAXPLAYERS + 1];
 
+int g_iClientTick[MAXPLAYERS + 1];
+
 /*===================================
 =         Predefined Arrays         =
 ===================================*/
@@ -2071,8 +2072,8 @@ public void OnClientDisconnect(int client)
 	{
 		if (g_bPause[client])
 		{
-			g_fPauseTime[client] = GetGameTime() - g_fStartPauseTime[client];
-			g_fPlayerLastTime[client] = GetGameTime() - g_fStartTime[client] - g_fPauseTime[client];
+			g_fPauseTime[client] = GetClientTickTime(client) - g_fStartPauseTime[client];
+			g_fPlayerLastTime[client] = GetClientTickTime(client) - g_fStartTime[client] - g_fPauseTime[client];
 		}
 		else
 		{

--- a/addons/sourcemod/scripting/surftimer/buttonpress.sp
+++ b/addons/sourcemod/scripting/surftimer/buttonpress.sp
@@ -1,48 +1,46 @@
 // Start Timer
 public void CL_OnStartTimerPress(int client)
 {
-	float fGetGameTime = GetGameTime();
-
 	if (!IsFakeClient(client))
 	{
 		if (IsValidClient(client))
 		{
 			if (!g_bServerDataLoaded)
 			{
-				if (fGetGameTime - g_fErrorMessage[client] > 1.0)
+				if (GetGameTime() - g_fErrorMessage[client] > 1.0)
 				{
 					CPrintToChat(client, "%t", "BPress1", g_szChatPrefix);
 					EmitSoundToClientNoPreCache(client, "play buttons\\button10.wav", false);
-					g_fErrorMessage[client] = fGetGameTime;
+					g_fErrorMessage[client] = GetGameTime();
 				}
 				return;
 			}
 			else if (g_bLoadingSettings[client])
 			{
-				if (fGetGameTime - g_fErrorMessage[client] > 1.0)
+				if (GetGameTime() - g_fErrorMessage[client] > 1.0)
 				{
 					CPrintToChat(client, "%t", "BPress2", g_szChatPrefix);
 					EmitSoundToClientNoPreCache(client, "play buttons\\button10.wav", false);
-					g_fErrorMessage[client] = fGetGameTime;
+					g_fErrorMessage[client] = GetGameTime();
 				}
 				return;
 			}
 			else if (!g_bSettingsLoaded[client])
 			{
-				if (fGetGameTime - g_fErrorMessage[client] > 1.0)
+				if (GetGameTime() - g_fErrorMessage[client] > 1.0)
 				{
 					CPrintToChat(client, "%t", "BPress3", g_szChatPrefix);
 					EmitSoundToClientNoPreCache(client, "play buttons\\button10.wav", false);
-					g_fErrorMessage[client] = fGetGameTime;
+					g_fErrorMessage[client] = GetGameTime();
 				}
 				return;
 			}
 		}
 		if (g_bNewReplay[client] || g_bNewBonus[client]) // Don't allow starting the timer, if players record is being saved
-		return;
+			return;
 	}
 
-	if (!g_bSpectate[client] && !g_bNoClip[client] && ((fGetGameTime - g_fLastTimeNoClipUsed[client]) > 2.0))
+	if (!g_bSpectate[client] && !g_bNoClip[client] && ((GetGameTime() - g_fLastTimeNoClipUsed[client]) > 2.0))
 	{
 		if (g_bActivateCheckpointsOnStart[client])
 		g_bCheckpointsEnabled[client] = true;
@@ -55,9 +53,9 @@ public void CL_OnStartTimerPress(int client)
 		g_bPause[client] = false;
 		SetEntityMoveType(client, MOVETYPE_WALK);
 		SetEntityRenderMode(client, RENDER_NORMAL);
-		g_fStartTime[client] = fGetGameTime;
+		g_fStartTime[client] = GetClientTickTime(client);
 		g_fCurrentRunTime[client] = 0.0;
-		g_fPracModeStartTime[client] = fGetGameTime;
+		g_fPracModeStartTime[client] = GetClientTickTime(client);
 		g_bPositionRestored[client] = false;
 		g_bMissedMapBest[client] = true;
 		g_bMissedBonusBest[client] = true;
@@ -214,7 +212,7 @@ public void CL_OnEndTimerPress(int client)
 	GetClientName(client, szName, 128);
 
 	// Get runtime and format it to a string
-	g_fFinalTime[client] = GetGameTime() - g_fStartTime[client] - g_fPauseTime[client];
+	g_fFinalTime[client] = GetClientTickTime(client) - g_fStartTime[client] - g_fPauseTime[client];
 	FormatTimeFloat(client, g_fFinalTime[client], 3, g_szFinalTime[client], 32);
 
 	/*====================================
@@ -759,7 +757,7 @@ public void CL_OnStartWrcpTimerPress(int client)
 		}
 		if (zGroup == 0)
 		{
-			g_fStartWrcpTime[client] = GetGameTime();
+			g_fStartWrcpTime[client] = GetClientTickTime(client);
 			g_fCurrentWrcpRunTime[client] = 0.0;
 			g_bWrcpTimeractivated[client] = true;
 			g_bNotTeleporting[client] = true;
@@ -909,7 +907,7 @@ public void CL_OnEndWrcpTimerPress(int client, float time2)
 	else if (g_bWrcpTimeractivated[client] && g_iCurrentStyle[client] != 0) // styles
 	{
 		int style = g_iCurrentStyle[client];
-		g_fFinalWrcpTime[client] = GetGameTime() - g_fStartWrcpTime[client];
+		g_fFinalWrcpTime[client] = GetClientTickTime(client) - g_fStartWrcpTime[client];
 		if (g_fFinalWrcpTime[client] <= 0.0)
 		{
 			CPrintToChat(client, "%t", "ErrorStageTime", g_szChatPrefix, stage);
@@ -939,9 +937,7 @@ public void CL_OnEndWrcpTimerPress(int client, float time2)
 
 public void CL_OnStartPracSrcpTimerPress(int client)
 {
-	float fGetGameTime = GetGameTime();
-
-	if (!g_bSpectate[client] && !g_bNoClip[client] && ((fGetGameTime - g_fLastTimeNoClipUsed[client]) > 2.0))
+	if (!g_bSpectate[client] && !g_bNoClip[client] && ((GetGameTime() - g_fLastTimeNoClipUsed[client]) > 2.0))
 	{
 		int zGroup = g_iClientInZone[client][2];
 		
@@ -954,7 +950,7 @@ public void CL_OnStartPracSrcpTimerPress(int client)
 		{
 			g_bPracSrcpTimerActivated[client] = true;
 			g_fSrcpPauseTime[client] = 0.0;
-			g_fStartPracSrcpTime[client] = fGetGameTime;
+			g_fStartPracSrcpTime[client] = GetClientTickTime(client);
 			
 			if (g_bSaveLocTele[client]) // Has the player teleported to saveloc?
 			{

--- a/addons/sourcemod/scripting/surftimer/commands.sp
+++ b/addons/sourcemod/scripting/surftimer/commands.sp
@@ -611,9 +611,7 @@ public Action Command_createPlayerCheckpoint(int client, int args)
 		}
 	}
 	
-	float fGetGameTime = GetGameTime();
-
-	if ((fGetGameTime - g_fLastCheckpointMade[client]) < 1.0)
+	if ((GetGameTime() - g_fLastCheckpointMade[client]) < 1.0)
 		return Plugin_Handled;
 
 	if (g_iSaveLocCount[client] < MAX_LOCS)
@@ -665,40 +663,40 @@ public Action Command_createPlayerCheckpoint(int client, int args)
 		{	
 			if (!g_bPracticeMode[player])
 			{
-				g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]] = fGetGameTime - g_fStartTime[player] - g_fPauseTime[player];
+				g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]] = GetClientTickTime(player) - g_fStartTime[player] - g_fPauseTime[player];
 			}
 			else
 			{
 				if (g_iPreviousSaveLocIdClient[player] == g_iLastSaveLocIdClient[player]) // Did player Tele to earlier saveloc?
 				{
-					g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]] = (fGetGameTime - g_fPracModeStartTime[player] - g_fPauseTime[player]) + g_fPlayerPracTimeSnap[player][g_iLastSaveLocIdClient[player] - 1];	
+					g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]] = (GetClientTickTime(player) - g_fPracModeStartTime[player] - g_fPauseTime[player]) + g_fPlayerPracTimeSnap[player][g_iLastSaveLocIdClient[player] - 1];	
 				}
 				else
 				{
-					g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]] = (fGetGameTime - g_fPracModeStartTime[player] - g_fPauseTime[player]) + g_fPlayerPracTimeSnap[player][g_iPreviousSaveLocIdClient[player]];
+					g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]] = (GetClientTickTime(player) - g_fPracModeStartTime[player] - g_fPauseTime[player]) + g_fPlayerPracTimeSnap[player][g_iPreviousSaveLocIdClient[player]];
 				}
 
-				g_fPracModeStartTime[client] = fGetGameTime;
+				g_fPracModeStartTime[client] = GetClientTickTime(player);
 			}
 		}
 		else if (g_bWrcpTimeractivated[player])
 		{
 			if (!g_bPracticeMode[player])
 			{
-				g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]] = fGetGameTime -  g_fStartWrcpTime[player] - g_fPauseTime[player];
+				g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]] = GetClientTickTime(player) -  g_fStartWrcpTime[player] - g_fPauseTime[player];
 			}
 			else
 			{
 				if (g_iPreviousSaveLocIdClient[player] == g_iLastSaveLocIdClient[player]) // Did player Tele to earlier saveloc?
 				{
-					g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]] = (fGetGameTime - g_fStartWrcpTime[player] - g_fPauseTime[player]) + g_fPlayerPracTimeSnap[player][g_iLastSaveLocIdClient[player] - 1];	
+					g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]] = (GetClientTickTime(player) - g_fStartWrcpTime[player] - g_fPauseTime[player]) + g_fPlayerPracTimeSnap[player][g_iLastSaveLocIdClient[player] - 1];	
 				}
 				else
 				{
-					g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]] = (fGetGameTime - g_fStartWrcpTime[player] - g_fPauseTime[player]) + g_fPlayerPracTimeSnap[player][g_iPreviousSaveLocIdClient[player]];
+					g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]] = (GetClientTickTime(player) - g_fStartWrcpTime[player] - g_fPauseTime[player]) + g_fPlayerPracTimeSnap[player][g_iPreviousSaveLocIdClient[player]];
 				}
 
-				g_fPracModeStartTime[client] = fGetGameTime;
+				g_fPracModeStartTime[client] = GetClientTickTime(player);
 			}
 		}
 
@@ -707,17 +705,17 @@ public Action Command_createPlayerCheckpoint(int client, int args)
 		{
 			if (!g_bPracticeMode[player])
 			{
-				g_fPlayerPracSrcpTimeSnap[client][g_iLastSaveLocIdClient[client]] = fGetGameTime -  g_fStartPracSrcpTime[player] - g_fPauseTime[player];
+				g_fPlayerPracSrcpTimeSnap[client][g_iLastSaveLocIdClient[client]] = GetClientTickTime(player) -  g_fStartPracSrcpTime[player] - g_fPauseTime[player];
 			}
 			else
 			{
 				if (g_iPreviousSaveLocIdClient[player] == g_iLastSaveLocIdClient[player]) // Did player Tele to earlier saveloc?
 				{	
-					g_fPlayerPracSrcpTimeSnap[client][g_iLastSaveLocIdClient[client]] = (fGetGameTime -  g_fStartPracSrcpTime[player] - g_fPauseTime[player]) + g_fPlayerPracSrcpTimeSnap[player][g_iLastSaveLocIdClient[player] - 1];
+					g_fPlayerPracSrcpTimeSnap[client][g_iLastSaveLocIdClient[client]] = (GetClientTickTime(player) -  g_fStartPracSrcpTime[player] - g_fPauseTime[player]) + g_fPlayerPracSrcpTimeSnap[player][g_iLastSaveLocIdClient[player] - 1];
 				}
 				else
 				{
-					g_fPlayerPracSrcpTimeSnap[client][g_iLastSaveLocIdClient[client]] = (fGetGameTime -  g_fStartPracSrcpTime[player] - g_fPauseTime[player]) + g_fPlayerPracSrcpTimeSnap[player][g_iPreviousSaveLocIdClient[player]];
+					g_fPlayerPracSrcpTimeSnap[client][g_iLastSaveLocIdClient[client]] = (GetClientTickTime(player) -  g_fStartPracSrcpTime[player] - g_fPauseTime[player]) + g_fPlayerPracSrcpTimeSnap[player][g_iPreviousSaveLocIdClient[player]];
 				}
 			}
 		}
@@ -757,7 +755,7 @@ public Action Command_createPlayerCheckpoint(int client, int args)
 			}
 		}
 
-		g_fLastCheckpointMade[client] = fGetGameTime;
+		g_fLastCheckpointMade[client] = GetGameTime();
 		g_iSaveLocUnix[g_iSaveLocCount[client]][client] = GetTime();
 
 		GetClientName(client, g_szSaveLocClientName[client][g_iSaveLocCount[client]], MAX_NAME_LENGTH);
@@ -786,7 +784,6 @@ public Action Command_goToPlayerCheckpoint(int client, int args)
 	if (g_iSaveLocCount[client] > 0)
 	{	
 		g_bSaveLocTele[client] = true;
-		g_fOldFinalWrcpTime[client] = 0.0;
 		
 		// This bypasses checkpoint enforcer when in PracMode as players wont always be passing all checkpoints
 		g_bIsValidRun[client] = true;
@@ -855,9 +852,7 @@ public Action Command_recreatePlayerCheckpoint(int client, int args)
 		return Plugin_Handled;
 	}
 
-	float fGetGameTime = GetGameTime();
-	
-	if ((fGetGameTime - g_fLastCheckpointMade[client]) < 1.0)
+	if ((GetGameTime() - g_fLastCheckpointMade[client]) < 1.0)
 		return Plugin_Handled;
 
 	if (g_iSaveLocCount[client] < MAX_LOCS)
@@ -901,7 +896,7 @@ public Action Command_recreatePlayerCheckpoint(int client, int args)
 			g_iSaveLocInBonus[client][id] = StringToInt(input[14]);
 
 			g_iSaveLocUnix[id][client] = GetTime();
-			g_fLastCheckpointMade[client] = fGetGameTime;
+			g_fLastCheckpointMade[client] = GetGameTime();
 
 			CReplyToCommand(client, "%t", "Commands7Added", g_szChatPrefix, id);
 			
@@ -1030,8 +1025,8 @@ public Action Command_Teleport(int client, int args)
 	// Throttle using !back to fix errors with replays
 	if ((GetGameTime() - g_fLastCommandBack[client]) < 1.0)
 		return Plugin_Handled;
-	else
-		g_fLastCommandBack[client] = GetGameTime();
+
+	g_fLastCommandBack[client] = GetGameTime();
 
 	if (g_Stage[g_iClientInZone[client][2]][client] == 1)
 	{
@@ -2574,7 +2569,7 @@ public void PauseMethod(int client)
 		// Timer enabled?
 		if (g_bTimerRunning[client] == true)
 		{
-			g_fStartPauseTime[client] = GetGameTime();
+			g_fStartPauseTime[client] = GetClientTickTime(client);
 			if (g_fPauseTime[client] > 0.0)
 			{
 				g_fStartPauseTime[client] = g_fStartPauseTime[client] - g_fPauseTime[client];
@@ -2587,7 +2582,7 @@ public void PauseMethod(int client)
 	{
 		if (g_fStartTime[client] != -1.0 && g_bTimerRunning[client] == true)
 		{
-			g_fPauseTime[client] = GetGameTime() - g_fStartPauseTime[client];
+			g_fPauseTime[client] = GetClientTickTime(client) - g_fStartPauseTime[client];
 			g_fSrcpPauseTime[client] = g_fPauseTime[client];
 		}
 
@@ -4030,8 +4025,7 @@ public int StyleSelectMenuHandler(Menu menu, MenuAction action, int param1, int 
 // Rate Limiting Commands
 public void RateLimit(int client)
 {
-	float currentTime = GetGameTime();
-	if (currentTime - g_fCommandLastUsed[client] < 2)
+	if (GetGameTime() - g_fCommandLastUsed[client] < 2)
 	{
 		CPrintToChat(client, "%t", "Commands46", g_szChatPrefix);
 		g_bRateLimit[client] = true;

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -486,7 +486,7 @@ void TeamChangeActual(int client, int toteam)
 	{
 		if (g_fStartTime[client] != -1.0 && g_bTimerRunning[client] == true)
 		{
-			g_fPauseTime[client] = GetGameTime() - g_fStartPauseTime[client];
+			g_fPauseTime[client] = GetClientTickTime(client) - g_fStartPauseTime[client];
 			
 			if (g_iClientInZone[client][0] == 3)
 			{
@@ -898,7 +898,6 @@ public Action CallAdmin_OnDrawOwnReason(int client)
 
 public bool checkSpam(int client)
 {
-	float time = GetGameTime();
 	if (GetConVarFloat(g_hChatSpamFilter) == 0.0)
 		return false;
 
@@ -907,7 +906,7 @@ public bool checkSpam(int client)
 
 	bool result = false;
 
-	if (time - g_fLastChatMessage[client] < GetConVarFloat(g_hChatSpamFilter))
+	if (GetGameTime() - g_fLastChatMessage[client] < GetConVarFloat(g_hChatSpamFilter))
 	{
 		result = true;
 		g_messages[client]++;
@@ -924,7 +923,7 @@ public bool checkSpam(int client)
 		return true;
 	}
 
-	g_fLastChatMessage[client] = time;
+	g_fLastChatMessage[client] = GetGameTime();
 	return result;
 }
 
@@ -1206,22 +1205,21 @@ public bool Base_TraceFilter(int entity, int contentsMask, any data)
 
 public void SetClientDefaults(int client)
 {
-	float GameTime = GetGameTime();
-	g_fLastCommandBack[client] = GameTime;
+	g_fLastCommandBack[client] = GetGameTime();
 	g_ClientSelectedZone[client] = -1;
 	g_Editing[client] = 0;
 	g_iSelectedTrigger[client] = -1;
 
 	g_bClientRestarting[client] = false;
-	g_fClientRestarting[client] = GameTime;
-	g_fErrorMessage[client] = GameTime;
+	g_fClientRestarting[client] = GetGameTime();
+	g_fErrorMessage[client] = GetGameTime();
 
 	g_bLoadingSettings[client] = false;
 	g_bSettingsLoaded[client] = false;
 
 	g_fLastDifferenceTime[client] = 0.0;
 
-	g_flastClientUsp[client] = GameTime;
+	g_flastClientUsp[client] = GetGameTime();
 
 	g_ClientRenamingZone[client] = false;
 
@@ -1266,7 +1264,7 @@ public void SetClientDefaults(int client)
 	g_fPauseTime[client] = 0.0;
 	g_MapRank[client] = 99999;
 	g_OldMapRank[client] = 99999;
-	g_fProfileMenuLastQuery[client] = GameTime;
+	g_fProfileMenuLastQuery[client] = GetGameTime();
 	Format(g_szPlayerPanelText[client], 512, "");
 	Format(g_pr_rankname[client], 128, "");
 	Format(g_pr_rankname_style[client], 32, "");
@@ -1291,7 +1289,7 @@ public void SetClientDefaults(int client)
 		}
 	}
 
-	// g_fLastPlayerCheckpoint[client] = GameTime;
+	// g_fLastPlayerCheckpoint[client] = GetGameTime();
 	g_bCreatedTeleport[client] = false;
 	g_bPracticeMode[client] = false;
 
@@ -1366,44 +1364,40 @@ public void SetClientDefaults(int client)
 
 	// New noclipspeed
 	g_iNoclipSpeed[client] = g_iDefaultNoclipSpeed;
+
+	g_iClientTick[client] = 0;
 }
 
-// Get Runtime
-public void GetcurrentRunTime(int client)
+float GetClientTickTime(int client)
 {
-	float fGetGameTime = GetGameTime();
-	float fPauseTime = g_fPauseTime[client];
-	float fSrcpPauseTime = g_fSrcpPauseTime[client];
+	return g_iClientTick[client] * GetTickInterval();
+}
 
+public void UpdateClientCurrentRunTimes(int client)
+{
 	if (g_bPracticeMode[client]) // If in PracMode then use normal CurrentRunTime + time from saveloc
 	{
-		g_fCurrentRunTime[client] = (fGetGameTime - g_fPracModeStartTime[client] - fPauseTime) + g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]];
+		g_fCurrentRunTime[client] = (GetClientTickTime(client) - g_fPracModeStartTime[client] - g_fPauseTime[client]) + g_fPlayerPracTimeSnap[client][g_iLastSaveLocIdClient[client]];
 	}
 	else // If not in PracMode then use normal CurrentRunTime
 	{
 		if (g_bTimerRunning[client])
-			g_fCurrentRunTime[client] = fGetGameTime - g_fStartTime[client] - fPauseTime;
+			g_fCurrentRunTime[client] = GetClientTickTime(client) - g_fStartTime[client] - g_fPauseTime[client];
 		else
 			g_fCurrentRunTime[client] = -1.0;
 	}
 	
 	if (g_bWrcpTimeractivated[client])
 	{
-		g_fCurrentWrcpRunTime[client] = fGetGameTime - g_fStartWrcpTime[client] - fSrcpPauseTime;
+		g_fCurrentWrcpRunTime[client] = GetClientTickTime(client) - g_fStartWrcpTime[client] - g_fSrcpPauseTime[client];
 	}
 
 	if (g_bPracSrcpTimerActivated[client])
 	{
-		float fStartPracSrcpTime = g_fStartPracSrcpTime[client];
-		
 		if (!g_bSaveLocTele[client])
-		{
-			g_fCurrentPracSrcpRunTime[client] = fGetGameTime - fStartPracSrcpTime - fSrcpPauseTime;
-		}
+			g_fCurrentPracSrcpRunTime[client] = GetClientTickTime(client) - g_fStartPracSrcpTime[client] - g_fSrcpPauseTime[client];
 		else
-		{
-			g_fCurrentPracSrcpRunTime[client] = (fGetGameTime - fStartPracSrcpTime - fSrcpPauseTime) + g_fPlayerPracSrcpTimeSnap[client][g_iLastSaveLocIdClient[client]];
-		}
+			g_fCurrentPracSrcpRunTime[client] = (GetClientTickTime(client) - g_fStartPracSrcpTime[client] - g_fSrcpPauseTime[client]) + g_fPlayerPracSrcpTimeSnap[client][g_iLastSaveLocIdClient[client]];
 	}
 }
 
@@ -2912,9 +2906,8 @@ public void SpecListMenuDead(int client) // What Spectators see
 				if (g_bTimerRunning[ObservedUser])
 				{
 					char szTime[32];
-					float Time;
-					Time = GetGameTime() - g_fStartTime[ObservedUser] - g_fPauseTime[ObservedUser];
-					FormatTimeFloat(client, Time, 4, szTime, sizeof(szTime));
+					float time = GetClientTickTime(ObservedUser) - g_fStartTime[ObservedUser] - g_fPauseTime[ObservedUser];
+					FormatTimeFloat(client, time, 4, szTime, sizeof(szTime));
 					if (!g_bPause[ObservedUser])
 					{
 						if (!IsFakeClient(ObservedUser))
@@ -3244,14 +3237,14 @@ public void CenterHudDead(int client)
 				}
 				else
 				{
-					obsTimer = GetGameTime() - g_fStartTime[ObservedUser] - g_fPauseTime[ObservedUser];
+					obsTimer = GetClientTickTime(ObservedUser) - g_fStartTime[ObservedUser] - g_fPauseTime[ObservedUser];
 				}
 
 				FormatTimeFloat(client, obsTimer, 3, obsAika, sizeof(obsAika));
 			}
 			else if (g_bWrcpTimeractivated[ObservedUser] && !g_bTimerRunning[ObservedUser])
 			{
-				obsTimer = GetGameTime() - g_fStartWrcpTime[ObservedUser] - g_fPauseTime[ObservedUser];
+				obsTimer = GetClientTickTime(ObservedUser) - g_fStartWrcpTime[ObservedUser] - g_fPauseTime[ObservedUser];
 				FormatTimeFloat(client, obsTimer, 3, obsAika, sizeof(obsAika));
 			}
 			else if (!g_bTimerEnabled[ObservedUser])
@@ -3288,8 +3281,6 @@ public void CenterHudAlive(int client)
 		int style = g_iCurrentStyle[client];
 		char module[6][1024];
 		char pAika[54];
-
-		float gametime = GetGameTime();
 
 		for (int i = 0; i < 6; i++)
 		{
@@ -3363,7 +3354,7 @@ public void CenterHudAlive(int client)
 			else if (g_iCentreHudModule[client][i] == 2)
 			{
 				// server records (change from WR)
-				if (gametime - g_fLastDifferenceTime[client] > 5.0)
+				if (GetGameTime() - g_fLastDifferenceTime[client] > 5.0)
 				{
 					if (g_iClientInZone[client][2] == 0 && style == 0)
 					{
@@ -3422,7 +3413,7 @@ public void CenterHudAlive(int client)
 			else if (g_iCentreHudModule[client][i] == 3)
 			{
 				// PB
-				if (gametime - g_fLastDifferenceTime[client] > 5.0)
+				if (GetGameTime() - g_fLastDifferenceTime[client] > 5.0)
 				{
 					if (g_iClientInZone[client][2] == 0 && style == 0)
 					{
@@ -4473,7 +4464,7 @@ public void TeleportToSaveloc(int client, int id)
 
 	CL_OnStartTimerPress(client);
 	CL_OnStartPracSrcpTimerPress(client);
-	GetcurrentRunTime(client);
+	UpdateClientCurrentRunTimes(client);
 	DispatchKeyValue(client, "targetname", g_szSaveLocTargetname[id]);
 	SetEntPropVector(client, Prop_Data, "m_vecVelocity", view_as<float>( { 0.0, 0.0, 0.0 } ));
 	TeleportEntity(client, g_fSaveLocCoords[client][id], g_fSaveLocAngle[client][id], g_fSaveLocVel[client][id]);

--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -3211,7 +3211,7 @@ public void SQL_LastRunCallback(Handle owner, Handle hndl, const char[] error, a
 		{
 			if (fl_time > 0.0)
 			{
-				g_fStartTime[data] = GetGameTime() - fl_time;
+				g_fStartTime[data] = GetClientTickTime(data) - fl_time;
 				g_bTimerRunning[data] = true;
 			}
 

--- a/addons/sourcemod/scripting/surftimer/timer.sp
+++ b/addons/sourcemod/scripting/surftimer/timer.sp
@@ -120,7 +120,6 @@ public Action CKTimer1(Handle timer)
 					CreateTimer(10.0, WelcomeMsgTimer, client, TIMER_FLAG_NO_MAPCHANGE);
 					CreateTimer(70.0, HelpMsgTimer, client, TIMER_FLAG_NO_MAPCHANGE);
 				}
-				GetcurrentRunTime(client);
 
 				CenterHudAlive(client);
 				MovementCheck(client);
@@ -224,18 +223,10 @@ public Action CKTimer2(Handle timer)
 		// Scoreboard
 		if (!g_bPause[i])
 		{
-			float fltime;
-			fltime = GetGameTime() - g_fStartTime[i] - g_fPauseTime[i] + 1.0;
 			if (IsPlayerAlive(i) && g_bTimerRunning[i])
-			{
-				int time;
-				time = RoundToZero(fltime);
-				Client_SetScore(i, time);
-			}
+				Client_SetScore(i, RoundToZero(GetClientTickTime(i) - g_fStartTime[i] - g_fPauseTime[i] + 1.0));
 			else
-			{
 				Client_SetScore(i, 0);
-			}
 
 			if (g_pr_AllPlayers[0] < g_PlayerRank[i][0] || g_PlayerRank[i][0] == 0)
 				CS_SetClientContributionScore(i, -99999);


### PR DESCRIPTION
### This PR fixes pretty severe timing issues with the timer. These issues make all record times inaccurate across the board (map, stage, checkpoints...).

#### Summary of changes:

- **Calculate times using client ticks instead of GetGameTime()** - Time should be calculated based on the number of executed playercmds and not server frames, since multiple playercmds (or none) may be processed in a single server frame. [Also, GetGameTime() is weird and returns a lag compensated value (?)](https://hlcoders.valvesoftware.narkive.com/IG3IBv9m/gpglobals-curtime). In any case, this change makes times independent of lag.

- **Make checkpoints accuracy higher than 0.1s** - Before, checkpoint times were only updated in 0.1s intervals (??)

- **Make EndTouchFix a requirement** - The engine calls EndTouch()s at the end of each server frame, not after each ProcessMovement. So if multiple playercmds are processed in 1 frame, trigger EndTouch calls might be delayed by a few client ticks. EndTouchFix fixes this issue and is required for having accurate times.

Resolves #282.

**Before/after video demonstrating the fix (same saveloc is restored but time is different after each completion):**

https://user-images.githubusercontent.com/16616463/152370121-c59112a8-9c9f-494b-9aea-f3d1dee450c0.mp4


[**Bonus exploit that is hopefully prevented now**](https://www.youtube.com/watch?v=p1AtpEcMnDk)

### I originally implemented this for [GoFree](https://stats.go-free.info) & @dPexxIAM. We've both decided to make this change public. Hopefully, this will make other people follow suit with sharing their bug fixes and contribute to SurfTimer :relaxed: