### PR TITLE
Increase size of string

### DIFF
--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -177,7 +177,7 @@ enum struct FileHeader
 {
 	int BinaryFormatVersion;
 	char Time[32];
-	char Playername[32];
+	char Playername[MAX_NAME_LENGTH];
 	int Checkpoints;
 	int TickCount;
 	float InitialPosition[3];


### PR DESCRIPTION
`MAX_NAME_LENGTH` is 128

UTF-8 character can take from 1 to 4 bytes to store, so if player has 8 and more 4-byte characters in his nickname (`𒂱𒂲𒂳𒂴𒂵𒂶𒂷𒂸𒂹𒂺𒂻` for example), we will have to lose some characters saving his movement to .rec file (`𒂸𒂹𒂺𒂻` from this example).
This change will not affect the reading of already written files.

If you think this change is not important: A few months ago I was working on a program that parses .rec files, this was a serious problem when the byte string ended unexpectedly and therefore could not be translated into a unicode string