### PR TITLE
Fix custom titles being truncated at 66 characters

### DIFF
--- a/addons/sourcemod/scripting/surftimer/sql.sp
+++ b/addons/sourcemod/scripting/surftimer/sql.sp
@@ -9256,7 +9256,7 @@ public void SQL_viewCustomTitlesCallback(Handle owner, Handle hndl, const char[]
 	if (SQL_HasResultSet(hndl) && SQL_FetchRow(hndl))
 	{
 		g_bdbHasCustomTitle[client] = true;
-		SQL_FetchString(hndl, 0, g_szCustomTitleColoured[client], sizeof(g_szCustomTitleColoured));
+		SQL_FetchString(hndl, 0, g_szCustomTitleColoured[client], sizeof(g_szCustomTitleColoured[]));
 
 		// fluffys temp fix for scoreboard
 		// int RankValue[SkillGroup];


### PR DESCRIPTION
the `sizeof` returned 66 (`MAXPLAYERS + 1`, the first field) instead of the desired 1024 (the second field) of `g_szCustomTitleColoured` which is defined like this:
https://github.com/surftimer/Surftimer-Official/blob/584571d07ff3e8b0f6b70bdd7a8a851a3ebae626/addons/sourcemod/scripting/SurfTimer.sp#L420

If someone had a very long custom title due to using a lot of colors, for example:
`{darkred}R{lightred}A{red}I{orange}N{yellow}B{lightgreen}O{green}W{blue}S{darkblue}Y{purple}A{pink}Y`
it got cut off at 66 characters due to this. Sometimes it even led to the nickname not being displayed in chat.