### PR TITLE
Limit TeleportClient to every 2 ticks

### DIFF
--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -132,6 +132,13 @@ public void teleportClient(int client, int zonegroup, int zone, bool stopTime)
 {
 	if (!IsValidClient(client))
 		return;
+
+	RateLimit(client);
+
+	if (g_bRateLimit[client])
+	{
+		return;
+	}
 	
 	// dpexx stop teleporting if in trigger_multiple
 	/* if (g_TeleInTriggerMultiple[client]){


### PR DESCRIPTION
Without this change, people can abuse boosters by double binding teleport commands. Very easy to abuse, especially when used in conjunction with sm_startpos