### PR TITLE
Stage 2 bug refix

### DIFF
--- a/addons/sourcemod/scripting/SurfTimer.sp
+++ b/addons/sourcemod/scripting/SurfTimer.sp
@@ -1112,9 +1112,6 @@ char g_BlockedChatText[256][256];
 // Last time an overlay was displayed
 float g_fLastOverlay[MAXPLAYERS + 1];
 
-// Stage 2 Bug Fixer
-bool g_wrcpStage2Fix[MAXPLAYERS + 1];
-
 // Is client trying to teleport inside a trigger_multiple
 //bool g_TeleInTriggerMultiple[MAXPLAYERS + 1];
 bool g_bTeleByCommand[MAXPLAYERS + 1];
@@ -1941,7 +1938,6 @@ public void OnClientConnected(int client)
 	g_Stage[0][client] = 1;
 	g_bWrcpTimeractivated[client] = false;
 	g_CurrentStage[client] = 1;
-	g_wrcpStage2Fix[client] = true;
 }
 
 public void OnClientPutInServer(int client)

--- a/addons/sourcemod/scripting/surftimer/buttonpress.sp
+++ b/addons/sourcemod/scripting/surftimer/buttonpress.sp
@@ -857,14 +857,6 @@ public void CL_OnEndWrcpTimerPress(int client, float time2)
 			CPrintToChat(client, "%t", "ErrorStageTime", g_szChatPrefix, stage);
 			return;
 		}
-		//Stage 1 to stage 2 glitch stopper.
-		if(g_wrcpStage2Fix[client] && stage == 2){
-			g_wrcpStage2Fix[client] = false;
-			CPrintToChat(client, "%t", "StageNotRecorded", g_szChatPrefix);
-			return;
-		}
-		
-		g_wrcpStage2Fix[client] = false;
 
 		char sz_srDiff[128];
 		float time = g_fFinalWrcpTime[client];

--- a/addons/sourcemod/scripting/surftimer/commands.sp
+++ b/addons/sourcemod/scripting/surftimer/commands.sp
@@ -1276,7 +1276,6 @@ public Action Command_ToStage(int client, int args)
 
 	g_fPauseTime[client] = 0.0;
 	g_fSrcpPauseTime[client] = 0.0;
-	g_wrcpStage2Fix[client] = false; // Stops "StageNotRecorded" when tele to s2, createloc, teletoloc, sm_rs, complete stage
 	
 	if (args < 1)
 	{

--- a/addons/sourcemod/scripting/surftimer/misc.sp
+++ b/addons/sourcemod/scripting/surftimer/misc.sp
@@ -1366,6 +1366,9 @@ public void SetClientDefaults(int client)
 	g_iNoclipSpeed[client] = g_iDefaultNoclipSpeed;
 
 	g_iClientTick[client] = 0;
+
+	g_bWrcpEndZone[client] = false;
+	g_iClientInZone[client][2] = 0;
 }
 
 float GetClientTickTime(int client)

--- a/addons/sourcemod/scripting/surftimer/surfzones.sp
+++ b/addons/sourcemod/scripting/surftimer/surfzones.sp
@@ -587,6 +587,8 @@ public void EndTouch(int client, int action[3])
 		{	
 			if (!g_bPracticeMode[client])
 			{
+				g_WrcpStage[client] = 1;
+				g_bWrcpEndZone[client] = false;
 				g_Stage[g_iClientInZone[client][2]][client] = 1;
 				lastCheckpoint[g_iClientInZone[client][2]][client] = 999;
 

--- a/addons/sourcemod/translations/surftimer.phrases.txt
+++ b/addons/sourcemod/translations/surftimer.phrases.txt
@@ -1646,11 +1646,6 @@
 		"#format"	"{1:s}"
 		"en"		"{1} Hints are now {red}disabled"
 	}
-	"StageNotRecorded"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1} Potential S1 to S2 glitch stopped. Stage time was not recorded"
-	}
 	"StartPrestrafe"
 	{
 		"#format"	"{1:s},{2:s},{3:s}"


### PR DESCRIPTION
https://discord.com/channels/366959507764674560/379572504542445568/414184575879610368
https://github.com/surftimer/Surftimer-Official/commit/d7892b7aadbbde5a4d8f6802471f7be5791c12a7

P.S. some of this code is useless
https://github.com/surftimer/Surftimer-Official/blob/7a59681913f04adb2e43e91fd55c5d355cc167a4/addons/sourcemod/scripting/surftimer/buttonpress.sp#L838-L842

At the end of the last stage, it increases by one (to `g_TotalStages + 1`), but immediately after that it returns to the total number of stages on map (to `g_TotalStages`)
https://github.com/surftimer/Surftimer-Official/blob/7a59681913f04adb2e43e91fd55c5d355cc167a4/addons/sourcemod/scripting/surftimer/buttonpress.sp#L844-L847

However, due to the fact that `g_bWrcpEndZone[client]` is not reset after `client`'s connecting, sometimes when you pass the first stage, you will be credited with passing the second one.

So should this `g_bWrcpEndZone` be completely removed?